### PR TITLE
Fix travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 cache:
   cargo: true
-  timeout: 1000
+  timeout: 1800
 
 rust:
   - nightly


### PR DESCRIPTION
Travis currently dies all the time trying to fetch the cache. This attempts to the mitigate that by increasing the timeout. if that won't do it, we just have to stop doing caching.